### PR TITLE
Added new instance: `cock.ceo`

### DIFF
--- a/backend/instances
+++ b/backend/instances
@@ -53,6 +53,7 @@ dl09.yt-dl.click,None,https
 cobalt-uk.programowanie.fun,cobalt-uk.axolotl.top,https
 cobalt-br.programowanie.fun,cobalt-br.axolotl.top,https
 cobalt-us.programowanie.fun,cobalt-us.axolotl.top,https
+api-cobalt.boykisser.systems,co.cock.ceo,https
 
 # instances without domains
 31.220.77.64:9000,31.220.77.64:9001,http


### PR DESCRIPTION
`co.cock.ceo` is using `boykisser.systems`'s API because it hosted on the same server.

Adding this instance because it much shorter than our original one, and maybe some people would use it instead that long one. In future we'll deploy it in another location, so they would be completely different.
Currently this instance supports Reddit, and TikTok.